### PR TITLE
Fix hardcoded backend URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,11 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Configuration
+
+The frontend expects the backend URL in the `VITE_API_URL` environment variable.
+Copy `.env.example` to `.env` and adjust the value if your backend runs on a different host or port.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from 'react';
 function App() {
   const [msg, setMsg] = useState('');
 
+  const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/';
+
   useEffect(() => {
-    fetch('http://localhost:5000/')
+    fetch(API_URL)
       .then(res => res.json())
       .then(data => {
         console.log('✅ Réponse du backend :', data.message); // Log côté navigateur
@@ -13,7 +15,7 @@ function App() {
       .catch(err => {
         console.error('❌ Erreur de connexion au backend :', err);
       });
-  }, []);
+  }, [API_URL]);
 
   return (
     <div className="p-6 text-center text-xl">


### PR DESCRIPTION
## Summary
- use `VITE_API_URL` in App.jsx so API endpoint can be configured
- document environment variable and provide example file

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68896e95f68c8326a8aaf3946b4f44c7