### PR TITLE
Implement REST API

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "dev": "node src/index.js"
+    "dev": "node src/index.js",
+    "seed": "node prisma/seed.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const password = await bcrypt.hash('password', 10);
+  const admin = await prisma.user.create({ data: { name: 'Admin', email: 'admin@example.com', password, role: 'admin' } });
+  const nutri = await prisma.user.create({ data: { name: 'Nutri', email: 'nutri@example.com', password, role: 'nutritionist' } });
+  const client = await prisma.user.create({ data: { name: 'Client', email: 'client@example.com', password, role: 'client' } });
+
+  const prog = await prisma.programme.create({ data: { title: 'Perte de poids', description: 'Programme de test', objective: 'perdre', created_by: nutri.id } });
+  await prisma.plat.create({ data: { title: 'Salade', description: 'Salade verte', created_by: nutri.id, programme_id: prog.id } });
+  await prisma.conseil.create({ data: { title: 'Boire', content: 'Boire de l eau', created_by: nutri.id, programme_id: prog.id } });
+}
+
+main().finally(() => prisma.$disconnect());

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -4,3 +4,35 @@ export const listUsers = async (req, res) => {
   const users = await prisma.user.findMany({ where: { role: { in: ['nutritionist', 'client'] } }, select: { id: true, name: true, email: true, role: true, is_active: true } });
   res.json(users);
 };
+
+export const toggleUser = async (req, res) => {
+  const { id } = req.params;
+  const current = await prisma.user.findUnique({ where: { id: Number(id) } });
+  if (!current) return res.status(404).json({ error: 'Not found' });
+  const user = await prisma.user.update({
+    where: { id: Number(id) },
+    data: { is_active: !current.is_active },
+  });
+  res.json(user);
+};
+
+export const deleteUser = async (req, res) => {
+  const { id } = req.params;
+  await prisma.user.delete({ where: { id: Number(id) } });
+  res.json({ message: 'Deleted' });
+};
+
+export const listContent = async (req, res) => {
+  const programmes = await prisma.programme.findMany();
+  const plats = await prisma.plat.findMany();
+  const conseils = await prisma.conseil.findMany();
+  res.json({ programmes, plats, conseils });
+};
+
+export const stats = async (req, res) => {
+  const usersByRole = await prisma.user.groupBy({ by: ['role'], _count: true });
+  const programmeCount = await prisma.programme.count();
+  const platCount = await prisma.plat.count();
+  const conseilCount = await prisma.conseil.count();
+  res.json({ usersByRole, programmeCount, platCount, conseilCount });
+};

--- a/backend/src/controllers/commentController.js
+++ b/backend/src/controllers/commentController.js
@@ -1,0 +1,54 @@
+import prisma from '../prismaClient.js';
+
+export const createComment = async (req, res) => {
+  const { type, target_id, content } = req.body;
+  try {
+    const comment = await prisma.commentaire.create({
+      data: {
+        type,
+        target_id: Number(target_id),
+        content,
+        user_id: req.user.id,
+      },
+    });
+    // notify owner
+    await createNotificationForTarget(type, target_id, 'new_comment');
+    res.json(comment);
+  } catch {
+    res.status(500).json({ error: 'Creation failed' });
+  }
+};
+
+export const getMyComments = async (req, res) => {
+  const comments = await prisma.commentaire.findMany({
+    where: { user_id: req.user.id },
+  });
+  res.json(comments);
+};
+
+export const getCommentsForTarget = async (req, res) => {
+  const { type, id } = req.params;
+  const comments = await prisma.commentaire.findMany({
+    where: { type, target_id: Number(id) },
+  });
+  res.json(comments);
+};
+
+async function createNotificationForTarget(type, target_id, notifType) {
+  const mapping = {
+    programme: prisma.programme,
+    plat: prisma.plat,
+    conseil: prisma.conseil,
+  };
+  const model = mapping[type];
+  if (!model) return;
+  const item = await model.findUnique({ where: { id: Number(target_id) } });
+  if (!item) return;
+  const ownerId = item.created_by;
+  if (ownerId === undefined) return;
+  await prisma.notification.create({
+    data: { user_id: ownerId, type: notifType, message: `${type} received a new comment` },
+  });
+}
+
+export default createNotificationForTarget;

--- a/backend/src/controllers/conseilController.js
+++ b/backend/src/controllers/conseilController.js
@@ -1,0 +1,48 @@
+import prisma from '../prismaClient.js';
+
+export const createConseil = async (req, res) => {
+  const { title, content, programmeId } = req.body;
+  try {
+    const conseil = await prisma.conseil.create({
+      data: {
+        title,
+        content,
+        is_global: !programmeId,
+        programme_id: programmeId ? Number(programmeId) : null,
+        created_by: req.user.id,
+      },
+    });
+    res.json(conseil);
+  } catch {
+    res.status(500).json({ error: 'Creation failed' });
+  }
+};
+
+export const updateConseil = async (req, res) => {
+  const { id } = req.params;
+  const { title, content } = req.body;
+  try {
+    const conseil = await prisma.conseil.update({
+      where: { id: Number(id) },
+      data: { title, content },
+    });
+    res.json(conseil);
+  } catch {
+    res.status(500).json({ error: 'Update failed' });
+  }
+};
+
+export const deleteConseil = async (req, res) => {
+  const { id } = req.params;
+  try {
+    await prisma.conseil.delete({ where: { id: Number(id) } });
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Deletion failed' });
+  }
+};
+
+export const getGlobalConseils = async (req, res) => {
+  const conseils = await prisma.conseil.findMany({ where: { is_global: true } });
+  res.json(conseils);
+};

--- a/backend/src/controllers/likeController.js
+++ b/backend/src/controllers/likeController.js
@@ -1,0 +1,37 @@
+import prisma from '../prismaClient.js';
+import createNotificationForTarget from './commentController.js';
+
+export const like = async (req, res) => {
+  const { type, target_id } = req.body;
+  try {
+    const existing = await prisma.like.findFirst({
+      where: { user_id: req.user.id, type, target_id: Number(target_id) },
+    });
+    if (existing) return res.status(400).json({ error: 'Already liked' });
+    const like = await prisma.like.create({
+      data: { user_id: req.user.id, type, target_id: Number(target_id) },
+    });
+    await createNotificationForTarget(type, target_id, 'new_like');
+    res.json(like);
+  } catch {
+    res.status(500).json({ error: 'Like failed' });
+  }
+};
+
+export const getLikesForNutritionist = async (req, res) => {
+  const programmes = await prisma.programme.findMany({
+    where: { created_by: req.user.id },
+    select: { id: true },
+  });
+  const ids = programmes.map(p => p.id);
+  const likes = await prisma.like.findMany({
+    where: {
+      OR: [
+        { type: 'programme', target_id: { in: ids } },
+        { type: 'plat', target_id: { in: (await prisma.plat.findMany({where:{created_by:req.user.id},select:{id:true}})).map(p=>p.id) } },
+        { type: 'conseil', target_id: { in: (await prisma.conseil.findMany({where:{created_by:req.user.id},select:{id:true}})).map(c=>c.id) } },
+      ],
+    },
+  });
+  res.json(likes);
+};

--- a/backend/src/controllers/notificationController.js
+++ b/backend/src/controllers/notificationController.js
@@ -1,0 +1,13 @@
+import prisma from '../prismaClient.js';
+
+export const getNotifications = async (req, res) => {
+  const notifs = await prisma.notification.findMany({
+    where: { user_id: req.user.id },
+    orderBy: { createdAt: 'desc' },
+  });
+  res.json(notifs);
+};
+
+export const createNotification = async (data) => {
+  return prisma.notification.create({ data });
+};

--- a/backend/src/controllers/platController.js
+++ b/backend/src/controllers/platController.js
@@ -1,0 +1,50 @@
+import prisma from '../prismaClient.js';
+
+export const createPlat = async (req, res) => {
+  const { title, description, image, benefits, programmeId } = req.body;
+  try {
+    const plat = await prisma.plat.create({
+      data: {
+        title,
+        description,
+        image,
+        benefits,
+        is_global: !programmeId,
+        programme_id: programmeId ? Number(programmeId) : null,
+        created_by: req.user.id,
+      },
+    });
+    res.json(plat);
+  } catch {
+    res.status(500).json({ error: 'Creation failed' });
+  }
+};
+
+export const updatePlat = async (req, res) => {
+  const { id } = req.params;
+  const { title, description, image, benefits } = req.body;
+  try {
+    const plat = await prisma.plat.update({
+      where: { id: Number(id) },
+      data: { title, description, image, benefits },
+    });
+    res.json(plat);
+  } catch {
+    res.status(500).json({ error: 'Update failed' });
+  }
+};
+
+export const deletePlat = async (req, res) => {
+  const { id } = req.params;
+  try {
+    await prisma.plat.delete({ where: { id: Number(id) } });
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Deletion failed' });
+  }
+};
+
+export const getGlobalPlats = async (req, res) => {
+  const plats = await prisma.plat.findMany({ where: { is_global: true } });
+  res.json(plats);
+};

--- a/backend/src/controllers/programmeController.js
+++ b/backend/src/controllers/programmeController.js
@@ -1,0 +1,83 @@
+import prisma from '../prismaClient.js';
+
+export const createProgramme = async (req, res) => {
+  const { title, description, objective, image } = req.body;
+  try {
+    const programme = await prisma.programme.create({
+      data: { title, description, objective, image, created_by: req.user.id },
+    });
+    res.json(programme);
+  } catch (err) {
+    res.status(500).json({ error: 'Creation failed' });
+  }
+};
+
+export const getProgrammes = async (req, res) => {
+  const programmes = await prisma.programme.findMany({
+    include: { plats: true, conseils: true },
+  });
+  res.json(programmes);
+};
+
+export const getProgramme = async (req, res) => {
+  const { id } = req.params;
+  const programme = await prisma.programme.findUnique({
+    where: { id: Number(id) },
+    include: { plats: true, conseils: true },
+  });
+  if (!programme) return res.status(404).json({ error: 'Not found' });
+  res.json(programme);
+};
+
+export const updateProgramme = async (req, res) => {
+  const { id } = req.params;
+  const { title, description, objective, image } = req.body;
+  try {
+    const programme = await prisma.programme.update({
+      where: { id: Number(id) },
+      data: { title, description, objective, image },
+    });
+    res.json(programme);
+  } catch (err) {
+    res.status(500).json({ error: 'Update failed' });
+  }
+};
+
+export const deleteProgramme = async (req, res) => {
+  const { id } = req.params;
+  try {
+    await prisma.programme.delete({ where: { id: Number(id) } });
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Deletion failed' });
+  }
+};
+
+export const followProgramme = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const exist = await prisma.suiviProgramme.findFirst({
+      where: { user_id: req.user.id, programme_id: Number(id) },
+    });
+    if (exist) return res.status(400).json({ error: 'Already following' });
+    const suivi = await prisma.suiviProgramme.create({
+      data: { user_id: req.user.id, programme_id: Number(id) },
+    });
+    res.json(suivi);
+  } catch {
+    res.status(500).json({ error: 'Follow failed' });
+  }
+};
+
+export const advanceSuivi = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const suivi = await prisma.suiviProgramme.update({
+      where: { id: Number(id) },
+      data: { current_step: { increment: 1 } },
+    });
+    res.json(suivi);
+  } catch {
+    res.status(500).json({ error: 'Advance failed' });
+  }
+};

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,0 +1,22 @@
+import bcrypt from 'bcryptjs';
+import prisma from '../prismaClient.js';
+
+export const updateProfile = async (req, res) => {
+  const { name, bio, avatar } = req.body;
+  const user = await prisma.user.update({
+    where: { id: req.user.id },
+    data: { name, bio, avatar },
+    select: { id: true, name: true, email: true, role: true, bio: true, avatar: true },
+  });
+  res.json(user);
+};
+
+export const changePassword = async (req, res) => {
+  const { oldPassword, newPassword } = req.body;
+  const user = await prisma.user.findUnique({ where: { id: req.user.id } });
+  const match = await bcrypt.compare(oldPassword, user.password);
+  if (!match) return res.status(400).json({ error: 'Invalid current password' });
+  const hashed = await bcrypt.hash(newPassword, 10);
+  await prisma.user.update({ where: { id: req.user.id }, data: { password: hashed } });
+  res.json({ message: 'Password updated' });
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,6 +3,14 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import authRoutes from './routes/auth.js';
 import adminRoutes from './routes/admin.js';
+import programmeRoutes from './routes/programmes.js';
+import platRoutes from './routes/plats.js';
+import conseilRoutes from './routes/conseils.js';
+import commentRoutes from './routes/commentaires.js';
+import likeRoutes from './routes/likes.js';
+import notifRoutes from './routes/notifications.js';
+import clientRoutes from './routes/client.js';
+import suiviRoutes from './routes/suivis.js';
 
 dotenv.config();
 
@@ -12,6 +20,14 @@ app.use(express.json());
 
 app.use('/api', authRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/programmes', programmeRoutes);
+app.use('/api/plats', platRoutes);
+app.use('/api/conseils', conseilRoutes);
+app.use('/api/commentaires', commentRoutes);
+app.use('/api/likes', likeRoutes);
+app.use('/api/notifications', notifRoutes);
+app.use('/api/client', clientRoutes);
+app.use('/api/suivis', suiviRoutes);
 
 app.get('/', (req, res) => {
   res.json({ message: 'API nutritionnelle' });

--- a/backend/src/routes/client.js
+++ b/backend/src/routes/client.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { updateProfile, changePassword } from '../controllers/userController.js';
+
+const router = Router();
+
+router.put('/profile', auth, role('client'), updateProfile);
+router.put('/password', auth, role('client'), changePassword);
+
+export default router;

--- a/backend/src/routes/commentaires.js
+++ b/backend/src/routes/commentaires.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import { createComment, getMyComments, getCommentsForTarget } from '../controllers/commentController.js';
+
+const router = Router();
+
+router.post('/', auth, createComment);
+router.get('/mine', auth, getMyComments);
+router.get('/:type/:id', getCommentsForTarget);
+
+export default router;

--- a/backend/src/routes/conseils.js
+++ b/backend/src/routes/conseils.js
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { createConseil, updateConseil, deleteConseil, getGlobalConseils } from '../controllers/conseilController.js';
+
+const router = Router();
+
+router.get('/', getGlobalConseils);
+router.post('/', auth, role('nutritionist'), createConseil);
+router.put('/:id', auth, role('nutritionist'), updateConseil);
+router.delete('/:id', auth, role('nutritionist'), deleteConseil);
+
+export default router;

--- a/backend/src/routes/likes.js
+++ b/backend/src/routes/likes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { like, getLikesForNutritionist } from '../controllers/likeController.js';
+
+const router = Router();
+
+router.post('/', auth, role('client'), like);
+router.get('/nutritionist', auth, role('nutritionist'), getLikesForNutritionist);
+
+export default router;

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import { getNotifications } from '../controllers/notificationController.js';
+
+const router = Router();
+
+router.get('/', auth, getNotifications);
+
+export default router;

--- a/backend/src/routes/plats.js
+++ b/backend/src/routes/plats.js
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { createPlat, updatePlat, deletePlat, getGlobalPlats } from '../controllers/platController.js';
+
+const router = Router();
+
+router.get('/', getGlobalPlats);
+router.post('/', auth, role('nutritionist'), createPlat);
+router.put('/:id', auth, role('nutritionist'), updatePlat);
+router.delete('/:id', auth, role('nutritionist'), deletePlat);
+
+export default router;

--- a/backend/src/routes/programmes.js
+++ b/backend/src/routes/programmes.js
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { createProgramme, getProgrammes, getProgramme, updateProgramme, deleteProgramme, followProgramme } from '../controllers/programmeController.js';
+
+const router = Router();
+
+router.get('/', getProgrammes);
+router.get('/:id', getProgramme);
+router.post('/', auth, role('nutritionist'), createProgramme);
+router.put('/:id', auth, role('nutritionist'), updateProgramme);
+router.delete('/:id', auth, role('nutritionist'), deleteProgramme);
+router.post('/:id/suivre', auth, role('client'), followProgramme);
+
+export default router;

--- a/backend/src/routes/suivis.js
+++ b/backend/src/routes/suivis.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { advanceSuivi } from '../controllers/programmeController.js';
+
+const router = Router();
+
+router.put('/:id/avancer', auth, role('client'), advanceSuivi);
+
+export default router;

--- a/backend/src/validators/programmeValidator.js
+++ b/backend/src/validators/programmeValidator.js
@@ -1,0 +1,8 @@
+import Joi from 'joi';
+
+export const programmeSchema = Joi.object({
+  title: Joi.string().required(),
+  description: Joi.string().required(),
+  objective: Joi.string().required(),
+  image: Joi.string().optional(),
+});


### PR DESCRIPTION
## Summary
- add controllers for programmes, plats, conseils, likes, comments, notifications and users
- expose routes for new resources
- add seed data script for Prisma
- wire routes into Express app
- include simple Joi validator

## Testing
- `npm run --silent dev` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68897ccf4b188326bd8c4e1135c2371c