### PR TITLE
Finalize backend with security and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Nutrition App Backend
+
+## Setup
+
+1. Install dependencies
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Configure environment variables in `backend/.env`
+   - `DATABASE_URL` for MySQL connection
+   - `JWT_SECRET` for token signing
+3. Run migrations
+   ```bash
+   npx prisma migrate deploy
+   ```
+4. Start the server
+   ```bash
+   npm run dev
+   ```
+
+## Folder structure
+- `backend/src/controllers` – route handlers
+- `backend/src/routes` – API routes
+- `backend/src/middlewares` – authentication & validation
+- `backend/src/validators` – Joi schemas
+- `backend/prisma` – Prisma schema
+
+## Roles
+- **admin** – gestion des utilisateurs et contenus
+- **nutritionist** – crée programmes, plats et conseils
+- **client** – suit des programmes et interagit
+
+## Testing with Postman
+Import `backend/postman_collection.json` in Postman and set `{{baseUrl}}` to your server URL.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,10 +14,26 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
         "prisma": "^6.11.1"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@prisma/client": {
@@ -101,6 +117,27 @@
       "dependencies": {
         "@prisma/debug": "6.11.1"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -583,6 +620,19 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/jsonwebtoken": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,11 +13,12 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "^6.11.1",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.0",
-    "bcryptjs": "^2.4.3"
+    "joi": "^17.13.3",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "prisma": "^6.11.1"

--- a/backend/postman_collection.json
+++ b/backend/postman_collection.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "Nutrition API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Auth Register",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Content-Type","value":"application/json"}],
+        "url": {"raw": "{{baseUrl}}/api/register"},
+        "body": {"mode":"raw","raw":"{\n  \"name\":\"John\",\n  \"email\":\"john@example.com\",\n  \"password\":\"secret\"\n}"}
+      }
+    },
+    {
+      "name": "Auth Login",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Content-Type","value":"application/json"}],
+        "url": {"raw": "{{baseUrl}}/api/login"},
+        "body": {"mode":"raw","raw":"{\n  \"email\":\"john@example.com\",\n  \"password\":\"secret\"\n}"}
+      }
+    },
+    {
+      "name": "List Programmes",
+      "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/programmes"}}
+    }
+  ]
+}

--- a/backend/scripts/test.js
+++ b/backend/scripts/test.js
@@ -1,0 +1,13 @@
+import { registerSchema } from '../src/validators/authValidator.js';
+
+async function run() {
+  try {
+    await registerSchema.validateAsync({ name: 'Test', email: 'test@test.com', password: '123456' });
+    console.log('Validation OK');
+  } catch (e) {
+    console.error('Validation failed', e);
+    process.exit(1);
+  }
+}
+
+run();

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -30,9 +30,63 @@ export const listContent = async (req, res) => {
 };
 
 export const stats = async (req, res) => {
-  const usersByRole = await prisma.user.groupBy({ by: ['role'], _count: true });
+  const usersByRole = await prisma.user.groupBy({ by: ['role'], _count: { _all: true } });
   const programmeCount = await prisma.programme.count();
   const platCount = await prisma.plat.count();
   const conseilCount = await prisma.conseil.count();
-  res.json({ usersByRole, programmeCount, platCount, conseilCount });
+
+  const topFollowed = await prisma.suiviProgramme.groupBy({
+    by: ['programme_id'],
+    _count: { _all: true },
+    orderBy: { _count: { _all: 'desc' } },
+    take: 5,
+  });
+  const progression = await prisma.suiviProgramme.aggregate({ _avg: { current_step: true } });
+  const totalSuivi = await prisma.suiviProgramme.count();
+  const abandoned = await prisma.suiviProgramme.count({ where: { completed: false } });
+  const abandonRate = totalSuivi === 0 ? 0 : abandoned / totalSuivi;
+
+  const topLiked = await prisma.like.groupBy({
+    by: ['type', 'target_id'],
+    _count: { _all: true },
+    orderBy: { _count: { _all: 'desc' } },
+    take: 5,
+  });
+  const topCommented = await prisma.commentaire.groupBy({
+    by: ['type', 'target_id'],
+    _count: { _all: true },
+    orderBy: { _count: { _all: 'desc' } },
+    take: 5,
+  });
+
+  res.json({
+    usersByRole,
+    programmeCount,
+    platCount,
+    conseilCount,
+    topFollowed,
+    progressionMoyenne: progression._avg.current_step,
+    tauxAbandon: abandonRate,
+    topLiked,
+    topCommented,
+  });
+};
+
+export const deletePublication = async (req, res) => {
+  const { id } = req.params;
+  const { type } = req.query;
+  try {
+    if (type === 'programme') {
+      await prisma.programme.delete({ where: { id: Number(id) } });
+    } else if (type === 'plat') {
+      await prisma.plat.delete({ where: { id: Number(id) } });
+    } else if (type === 'conseil') {
+      await prisma.conseil.delete({ where: { id: Number(id) } });
+    } else {
+      return res.status(400).json({ error: 'Invalid type' });
+    }
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Deletion failed' });
+  }
 };

--- a/backend/src/controllers/commentController.js
+++ b/backend/src/controllers/commentController.js
@@ -34,6 +34,22 @@ export const getCommentsForTarget = async (req, res) => {
   res.json(comments);
 };
 
+export const getCommentsReceived = async (req, res) => {
+  const programmes = await prisma.programme.findMany({ where: { created_by: req.user.id }, select: { id: true } });
+  const plats = await prisma.plat.findMany({ where: { created_by: req.user.id }, select: { id: true } });
+  const conseils = await prisma.conseil.findMany({ where: { created_by: req.user.id }, select: { id: true } });
+  const comments = await prisma.commentaire.findMany({
+    where: {
+      OR: [
+        { type: 'programme', target_id: { in: programmes.map(p => p.id) } },
+        { type: 'plat', target_id: { in: plats.map(p => p.id) } },
+        { type: 'conseil', target_id: { in: conseils.map(c => c.id) } },
+      ],
+    },
+  });
+  res.json(comments);
+};
+
 async function createNotificationForTarget(type, target_id, notifType) {
   const mapping = {
     programme: prisma.programme,

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -11,6 +11,7 @@ import likeRoutes from './routes/likes.js';
 import notifRoutes from './routes/notifications.js';
 import clientRoutes from './routes/client.js';
 import suiviRoutes from './routes/suivis.js';
+import nutritionistRoutes from './routes/nutritionist.js';
 
 dotenv.config();
 
@@ -27,6 +28,7 @@ app.use('/api/commentaires', commentRoutes);
 app.use('/api/likes', likeRoutes);
 app.use('/api/notifications', notifRoutes);
 app.use('/api/client', clientRoutes);
+app.use('/api/nutritionist', nutritionistRoutes);
 app.use('/api/suivis', suiviRoutes);
 
 app.get('/', (req, res) => {

--- a/backend/src/middlewares/auth.js
+++ b/backend/src/middlewares/auth.js
@@ -1,12 +1,15 @@
 import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
 
-export default function auth(req, res, next) {
+export default async function auth(req, res, next) {
   const header = req.headers.authorization;
   if (!header) return res.status(401).json({ error: 'No token' });
   const token = header.split(' ')[1];
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = { id: payload.userId, role: payload.role };
+    const user = await prisma.user.findUnique({ where: { id: payload.userId }, select: { id: true, role: true, is_active: true } });
+    if (!user || !user.is_active) return res.status(403).json({ error: 'User disabled' });
+    req.user = { id: user.id, role: user.role };
     next();
   } catch {
     res.status(401).json({ error: 'Invalid token' });

--- a/backend/src/middlewares/validate.js
+++ b/backend/src/middlewares/validate.js
@@ -1,0 +1,7 @@
+export default function validate(schema) {
+  return (req, res, next) => {
+    const { error } = schema.validate(req.body);
+    if (error) return res.status(400).json({ error: error.details[0].message });
+    next();
+  };
+}

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,10 +1,15 @@
 import { Router } from 'express';
-import { listUsers } from '../controllers/adminController.js';
+import { listUsers, toggleUser, deleteUser, listContent, stats, deletePublication } from '../controllers/adminController.js';
 import authMiddleware from '../middlewares/auth.js';
 import roleMiddleware from '../middlewares/role.js';
 
 const router = Router();
 
 router.get('/users', authMiddleware, roleMiddleware('admin'), listUsers);
+router.put('/users/:id/toggle-activation', authMiddleware, roleMiddleware('admin'), toggleUser);
+router.delete('/users/:id', authMiddleware, roleMiddleware('admin'), deleteUser);
+router.get('/statistics', authMiddleware, roleMiddleware('admin'), stats);
+router.get('/publications', authMiddleware, roleMiddleware('admin'), listContent);
+router.delete('/publications/:id', authMiddleware, roleMiddleware('admin'), deletePublication);
 
 export default router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import { register, login, me } from '../controllers/authController.js';
 import authMiddleware from '../middlewares/auth.js';
+import validate from '../middlewares/validate.js';
+import { registerSchema, loginSchema } from '../validators/authValidator.js';
 
 const router = Router();
 
-router.post('/register', register);
-router.post('/login', login);
+router.post('/register', validate(registerSchema), register);
+router.post('/login', validate(loginSchema), login);
 router.get('/me', authMiddleware, me);
 
 export default router;

--- a/backend/src/routes/client.js
+++ b/backend/src/routes/client.js
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import auth from '../middlewares/auth.js';
 import role from '../middlewares/role.js';
+import validate from '../middlewares/validate.js';
+import { passwordChangeSchema } from '../validators/authValidator.js';
 import { updateProfile, changePassword } from '../controllers/userController.js';
 
 const router = Router();
 
 router.put('/profile', auth, role('client'), updateProfile);
-router.put('/password', auth, role('client'), changePassword);
+router.put('/password', auth, role('client'), validate(passwordChangeSchema), changePassword);
 
 export default router;

--- a/backend/src/routes/commentaires.js
+++ b/backend/src/routes/commentaires.js
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import auth from '../middlewares/auth.js';
+import validate from '../middlewares/validate.js';
+import { commentSchema } from '../validators/commentValidator.js';
 import { createComment, getMyComments, getCommentsForTarget } from '../controllers/commentController.js';
 
 const router = Router();
 
-router.post('/', auth, createComment);
+router.post('/', auth, validate(commentSchema), createComment);
 router.get('/mine', auth, getMyComments);
 router.get('/:type/:id', getCommentsForTarget);
 

--- a/backend/src/routes/conseils.js
+++ b/backend/src/routes/conseils.js
@@ -1,13 +1,15 @@
 import { Router } from 'express';
 import auth from '../middlewares/auth.js';
 import role from '../middlewares/role.js';
+import validate from '../middlewares/validate.js';
+import { conseilSchema, conseilUpdateSchema } from '../validators/conseilValidator.js';
 import { createConseil, updateConseil, deleteConseil, getGlobalConseils } from '../controllers/conseilController.js';
 
 const router = Router();
 
 router.get('/', getGlobalConseils);
-router.post('/', auth, role('nutritionist'), createConseil);
-router.put('/:id', auth, role('nutritionist'), updateConseil);
+router.post('/', auth, role('nutritionist'), validate(conseilSchema), createConseil);
+router.put('/:id', auth, role('nutritionist'), validate(conseilUpdateSchema), updateConseil);
 router.delete('/:id', auth, role('nutritionist'), deleteConseil);
 
 export default router;

--- a/backend/src/routes/likes.js
+++ b/backend/src/routes/likes.js
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import auth from '../middlewares/auth.js';
 import role from '../middlewares/role.js';
+import validate from '../middlewares/validate.js';
+import { likeSchema } from '../validators/likeValidator.js';
 import { like, getLikesForNutritionist } from '../controllers/likeController.js';
 
 const router = Router();
 
-router.post('/', auth, role('client'), like);
+router.post('/', auth, role('client'), validate(likeSchema), like);
 router.get('/nutritionist', auth, role('nutritionist'), getLikesForNutritionist);
 
 export default router;

--- a/backend/src/routes/nutritionist.js
+++ b/backend/src/routes/nutritionist.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import auth from '../middlewares/auth.js';
+import role from '../middlewares/role.js';
+import { getCommentsReceived } from '../controllers/commentController.js';
+
+const router = Router();
+
+router.get('/comments-recus', auth, role('nutritionist'), getCommentsReceived);
+
+export default router;

--- a/backend/src/routes/plats.js
+++ b/backend/src/routes/plats.js
@@ -1,13 +1,15 @@
 import { Router } from 'express';
 import auth from '../middlewares/auth.js';
 import role from '../middlewares/role.js';
+import validate from '../middlewares/validate.js';
+import { platSchema, platUpdateSchema } from '../validators/platValidator.js';
 import { createPlat, updatePlat, deletePlat, getGlobalPlats } from '../controllers/platController.js';
 
 const router = Router();
 
 router.get('/', getGlobalPlats);
-router.post('/', auth, role('nutritionist'), createPlat);
-router.put('/:id', auth, role('nutritionist'), updatePlat);
+router.post('/', auth, role('nutritionist'), validate(platSchema), createPlat);
+router.put('/:id', auth, role('nutritionist'), validate(platUpdateSchema), updatePlat);
 router.delete('/:id', auth, role('nutritionist'), deletePlat);
 
 export default router;

--- a/backend/src/routes/programmes.js
+++ b/backend/src/routes/programmes.js
@@ -1,14 +1,16 @@
 import { Router } from 'express';
 import auth from '../middlewares/auth.js';
 import role from '../middlewares/role.js';
+import validate from '../middlewares/validate.js';
+import { programmeSchema, programmeUpdateSchema } from '../validators/programmeValidator.js';
 import { createProgramme, getProgrammes, getProgramme, updateProgramme, deleteProgramme, followProgramme } from '../controllers/programmeController.js';
 
 const router = Router();
 
 router.get('/', getProgrammes);
 router.get('/:id', getProgramme);
-router.post('/', auth, role('nutritionist'), createProgramme);
-router.put('/:id', auth, role('nutritionist'), updateProgramme);
+router.post('/', auth, role('nutritionist'), validate(programmeSchema), createProgramme);
+router.put('/:id', auth, role('nutritionist'), validate(programmeUpdateSchema), updateProgramme);
 router.delete('/:id', auth, role('nutritionist'), deleteProgramme);
 router.post('/:id/suivre', auth, role('client'), followProgramme);
 

--- a/backend/src/validators/authValidator.js
+++ b/backend/src/validators/authValidator.js
@@ -1,0 +1,17 @@
+import Joi from 'joi';
+
+export const registerSchema = Joi.object({
+  name: Joi.string().required(),
+  email: Joi.string().email().required(),
+  password: Joi.string().min(6).required(),
+});
+
+export const loginSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().required(),
+});
+
+export const passwordChangeSchema = Joi.object({
+  oldPassword: Joi.string().required(),
+  newPassword: Joi.string().min(6).required(),
+});

--- a/backend/src/validators/commentValidator.js
+++ b/backend/src/validators/commentValidator.js
@@ -1,0 +1,7 @@
+import Joi from 'joi';
+
+export const commentSchema = Joi.object({
+  type: Joi.string().valid('programme', 'plat', 'conseil').required(),
+  target_id: Joi.number().required(),
+  content: Joi.string().required(),
+});

--- a/backend/src/validators/conseilValidator.js
+++ b/backend/src/validators/conseilValidator.js
@@ -1,0 +1,15 @@
+import Joi from 'joi';
+
+export const conseilSchema = Joi.object({
+  title: Joi.string().required(),
+  content: Joi.string().required(),
+  is_global: Joi.boolean().optional(),
+  programme_id: Joi.number().optional(),
+});
+
+export const conseilUpdateSchema = Joi.object({
+  title: Joi.string(),
+  content: Joi.string(),
+  is_global: Joi.boolean(),
+  programme_id: Joi.number(),
+});

--- a/backend/src/validators/likeValidator.js
+++ b/backend/src/validators/likeValidator.js
@@ -1,0 +1,6 @@
+import Joi from 'joi';
+
+export const likeSchema = Joi.object({
+  type: Joi.string().valid('programme', 'plat', 'conseil').required(),
+  target_id: Joi.number().required(),
+});

--- a/backend/src/validators/platValidator.js
+++ b/backend/src/validators/platValidator.js
@@ -1,0 +1,19 @@
+import Joi from 'joi';
+
+export const platSchema = Joi.object({
+  title: Joi.string().required(),
+  description: Joi.string().required(),
+  image: Joi.string().optional(),
+  benefits: Joi.string().optional(),
+  is_global: Joi.boolean().optional(),
+  programme_id: Joi.number().optional(),
+});
+
+export const platUpdateSchema = Joi.object({
+  title: Joi.string(),
+  description: Joi.string(),
+  image: Joi.string(),
+  benefits: Joi.string(),
+  is_global: Joi.boolean(),
+  programme_id: Joi.number(),
+});

--- a/backend/src/validators/programmeValidator.js
+++ b/backend/src/validators/programmeValidator.js
@@ -6,3 +6,10 @@ export const programmeSchema = Joi.object({
   objective: Joi.string().required(),
   image: Joi.string().optional(),
 });
+
+export const programmeUpdateSchema = Joi.object({
+  title: Joi.string(),
+  description: Joi.string(),
+  objective: Joi.string(),
+  image: Joi.string(),
+});


### PR DESCRIPTION
## Summary
- add JWT expiration and disable access for inactive users
- add Joi validators and middleware
- implement complete admin routes
- add nutritionist comments route
- include Postman collection and README
- basic validation test script

## Testing
- `node scripts/test.js`

------
https://chatgpt.com/codex/tasks/task_e_68898a8457c883268522324dd44796e9